### PR TITLE
Add installation for Chrome and related pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,17 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk8-installer
 
+RUN \
+  apt-get update && \
+  apt-get install -y libnss3 libfontconfig
+
+RUN \
+  apt-get update && \
+  apt-get install -y libxss1 libappindicator1 libindicator7 libasound2 fonts-liberation xdg-utils && \
+  wget -N https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  sudo dpkg -i google-chrome-stable_current_amd64.deb && \
+  sudo apt-get -f install -y && \
+  sudo dpkg -i google-chrome-stable_current_amd64.deb
+
+
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,13 @@ RUN \
   echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
   add-apt-repository -y ppa:webupd8team/java && \
   apt-get update && \
-  apt-get install -y oracle-java8-installer unzip xvfb libxi6 libgconf-2-4 && \
+  apt-get install -y oracle-java8-installer unzip xvfb libxi6 libgconf-2-4 libnss3 libfontconfig \
+  libxss1 libappindicator1 libindicator7 libasound2 fonts-liberation xdg-utils && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/oracle-jdk8-installer
 
-RUN \
-  apt-get update && \
-  apt-get install -y libnss3 libfontconfig
 
 RUN \
-  apt-get update && \
-  apt-get install -y libxss1 libappindicator1 libindicator7 libasound2 fonts-liberation xdg-utils && \
   wget -N https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
   sudo dpkg -i google-chrome-stable_current_amd64.deb && \
   sudo apt-get -f install -y && \


### PR DESCRIPTION
The `docker build` passed with no errors on my local machine.

But when i `docker run` inside that container, and `google-chrome` returns me this:
```
#> google-chrome
Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted
Trace/breakpoint trap
```

Not sure if this is expected or not. 